### PR TITLE
Fix of Issue #1 - API_KEY usage via .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Want to contribute? Here's how:
 1.  First ```fork``` and ```star``` the project.
 2.  Run ```npm install``` to install all needed dependencies.
 3.  Navigate to [OpenWeatherMap's ](http://openweathermap.org/) and get a free API key. 
-r.  Set your API Key. There are two methods:
+4.  Set your API Key. There are two methods:
 	
 	- Set an environment variable: ```API_KEY```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Node js application that accepts a location input or uses the users IP address t
 
 * [request](https://github.com/request/request) - simple HTTP client
 * [yargs](http://yargs.js.org/) - for easy variables in the command line
+* [dotenv](https://www.npmjs.com/package/dotenv) - Environment variables storage in file
 * [OpenWeatherMap](http://openweathermap.org/) - free weather api
 * [IPinfo.io](http://ipinfo.io/) - free ip location lookup api
 
@@ -14,6 +15,7 @@ Node js application that accepts a location input or uses the users IP address t
 
 ###HACKTOBERFEST!
 
+<<<<<<< HEAD
 Want to contribute? Here's how:
 
 1.  First ```fork``` and ```star``` the project.
@@ -26,4 +28,19 @@ Want to contribute? Here's how:
 5.  Request the weather for your current location (as determined by IP) by running: ```npm start```
 6.  Specify any location by using the location flag: ```npm start -- -l Boston```
 7.  Browse the open issues, join the discussion, and push your code. All accepted Pull Requests will have their names added as contributors to the project. Thanks for all your help!
+=======
+1.  ```npm install```
+
+2.  Navigate to [OpenWeatherMap](http://openweathermap.org/) and request your free API Key. 
+
+3.  Set your API Key. There are two methods:
+	
+	- Set an environment variable: ```API_KEY```
+
+    	Example: ```API_KEY=yourKeyHere```
+
+    	Windows Example: ```SET API_KEY=yourKeyHere```
+
+    - Create a `.env` file in the root of the project with the content of ```API_KEY=yourKeyHere```
+>>>>>>> 9915898... Resolving issue #1. Added capability of using a  file in place of setting an environment variable for setting up the API key.
 

--- a/README.md
+++ b/README.md
@@ -15,25 +15,12 @@ Node js application that accepts a location input or uses the users IP address t
 
 ###HACKTOBERFEST!
 
-<<<<<<< HEAD
 Want to contribute? Here's how:
 
 1.  First ```fork``` and ```star``` the project.
 2.  Run ```npm install``` to install all needed dependencies.
 3.  Navigate to [OpenWeatherMap's ](http://openweathermap.org/) and get a free API key. 
-4.  Set your API Key to your machine using enviornment variables: ```API_KEY```
-    
-    Example: ```API_KEY=yourKeyHere```
-    Windows Example: ```SET API_KEY=yourKeyHere```
-5.  Request the weather for your current location (as determined by IP) by running: ```npm start```
-6.  Specify any location by using the location flag: ```npm start -- -l Boston```
-7.  Browse the open issues, join the discussion, and push your code. All accepted Pull Requests will have their names added as contributors to the project. Thanks for all your help!
-=======
-1.  ```npm install```
-
-2.  Navigate to [OpenWeatherMap](http://openweathermap.org/) and request your free API Key. 
-
-3.  Set your API Key. There are two methods:
+r.  Set your API Key. There are two methods:
 	
 	- Set an environment variable: ```API_KEY```
 
@@ -42,5 +29,7 @@ Want to contribute? Here's how:
     	Windows Example: ```SET API_KEY=yourKeyHere```
 
     - Create a `.env` file in the root of the project with the content of ```API_KEY=yourKeyHere```
->>>>>>> 9915898... Resolving issue #1. Added capability of using a  file in place of setting an environment variable for setting up the API key.
 
+5.  Request the weather for your current location (as determined by IP) by running: ```npm start```
+6.  Specify any location by using the location flag: ```npm start -- -l Boston```
+7.  Browse the open issues, join the discussion, and push your code. All accepted Pull Requests will have their names added as contributors to the project. Thanks for all your help!

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config({silent:true});
 var weather = require('./weather.js');
 var location = require('./location.js');
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/bmorelli25/node-async-weather#readme",
   "dependencies": {
+    "dotenv": "^2.0.0",
     "request": "^2.60.0",
     "yargs": "^3.15.0"
   }

--- a/weather.js
+++ b/weather.js
@@ -2,12 +2,12 @@ var request = require('request');
 
 module.exports = function (location) {
   return new Promise (function (resolve, reject) {
-    var apiKey = process.env.API_KEY;
-    if(typeof(apiKey) == "undefined" || apiKey.length == 0) {
+    var API_KEY = process.env.API_KEY;
+    if(typeof(API_KEY) == "undefined" || API_KEY.length == 0) {
       return reject("No API key set. (Create a .env file or set an API_KEY environment variable)");
     }
 
-    var url = `http://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(location)}&units=imperial&APPID=${apiKey}`;
+    var url = `http://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(location)}&units=imperial&APPID=${API_KEY}`;
 
     if (!location) {
       reject('No Location Provided');

--- a/weather.js
+++ b/weather.js
@@ -3,6 +3,10 @@ var request = require('request');
 module.exports = function (location) {
   return new Promise (function (resolve, reject) {
     var apiKey = process.env.API_KEY;
+    if(typeof(apiKey) == "undefined" || apiKey.length == 0) {
+      return reject("No API key set. (Create a .env file or set an API_KEY environment variable)");
+    }
+
     var url = `http://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(location)}&units=imperial&APPID=${apiKey}`;
 
     if (!location) {
@@ -16,7 +20,7 @@ module.exports = function (location) {
       if (error) {
         reject('Unable to fetch Weather: ', error.message);
       } else { // Print entire JSON 'nicely': console.log(JSON.stringify(body, null, 4));
-        var location = body.name
+        var location = body.name;
         var temp = body.main.temp;
         var message = `It's ${temp} degrees in ${location}!`;
         resolve(message);


### PR DESCRIPTION
Added dotenv library in order to handle file replacement of API_KEY entry. Environment variable is still usable in place of .env file. Also added some error checking if no API_KEY is available. 
